### PR TITLE
Fix(chatbot): Correct prompt formatting for conversation history

### DIFF
--- a/src/chatbot/engine.py
+++ b/src/chatbot/engine.py
@@ -12,7 +12,7 @@ class ChatbotEngine:
 
         # Join the history with the model's end-of-string token to create the prompt.
         # This is the format DialoGPT expects.
-        prompt = "".join(self.conversation_history) + self.chatbot.tokenizer.eos_token
+        prompt = self.chatbot.tokenizer.eos_token.join(self.conversation_history) + self.chatbot.tokenizer.eos_token
 
         # Generate the response.
         response = self.chatbot(prompt, max_length=1000, pad_token_id=self.chatbot.tokenizer.eos_token_id)
@@ -22,6 +22,6 @@ class ChatbotEngine:
         bot_response = full_response[len(prompt):].strip()
 
         # Append the bot's response to the history for the next turn.
-        self.conversation_history.append(bot_response + self.chatbot.tokenizer.eos_token)
+        self.conversation_history.append(bot_response)
 
         return bot_response

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from src.chatbot.engine import ChatbotEngine
+
+class TestChatbotEngine(unittest.TestCase):
+
+    @patch('src.chatbot.engine.pipeline')
+    def test_prompt_formatting(self, mock_pipeline):
+        # Arrange
+        # Create a mock for the tokenizer and the pipeline
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.eos_token = "<|endoftext|>"
+        mock_tokenizer.eos_token_id = 50256
+
+        mock_chatbot_pipeline = MagicMock()
+        mock_chatbot_pipeline.tokenizer = mock_tokenizer
+        # Configure the mock pipeline to return a predefined response
+        mock_chatbot_pipeline.return_value = [{'generated_text': "Hello<|endoftext|>Hi there!"}]
+        mock_pipeline.return_value = mock_chatbot_pipeline
+
+        engine = ChatbotEngine()
+
+        # Act
+        engine.get_response("Hello") # First turn
+        engine.get_response("How are you?") # Second turn
+
+        # Assert
+        # Check the prompt passed to the text-generation pipeline on the *second* call
+        # The history should be ["Hello", "Hi there!", "How are you?"]
+        # The buggy prompt is "HelloHi there!<|endoftext|>How are you?<|endoftext|>"
+        # The correct prompt should be "Hello<|endoftext|>Hi there!<|endoftext|>How are you?<|endoftext|>"
+
+        # To get the bot response for the first turn, we need to simulate the logic
+        # from the engine's get_response method.
+        # prompt1 = "Hello" + mock_tokenizer.eos_token -> "Hello<|endoftext|>"
+        # full_response1 = "Hello<|endoftext|>Hi there!"
+        # bot_response1 = "Hi there!"
+        # history after turn 1 = ["Hello", "Hi there!<|endoftext|>"]
+
+        # prompt2 = "HelloHi there!<|endoftext|>How are you?" + mock_tokenizer.eos_token
+        # -> "HelloHi there!<|endoftext|>How are you?<|endoftext|>"
+
+        # Let's get the actual call from the mock
+        # The second call to the pipeline is what we want to inspect.
+        args, kwargs = mock_chatbot_pipeline.call_args_list[1]
+        actual_prompt = args[0]
+
+        expected_prompt = "Hello<|endoftext|>Hi there!<|endoftext|>How are you?<|endoftext|>"
+
+        # This assertion will fail with the current implementation
+        self.assertEqual(expected_prompt, actual_prompt)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The chatbot engine was incorrectly constructing the prompt for the conversational model. It joined conversation turns without the required `eos_token` separator, leading to a malformed prompt where user inputs and bot responses were directly concatenated. This prevented the model from correctly understanding the conversation flow.

This commit addresses the issue by:
1.  Joining the conversation history with the tokenizer's `eos_token` to create a correctly formatted prompt.
2.  Removing the redundant storage of the `eos_token` within the conversation history list itself.

A new unit test has been added in `tests/test_chatbot.py` to specifically verify the correct prompt formatting. This test fails with the previous implementation and passes with this fix, ensuring the bug is resolved and preventing future regressions.